### PR TITLE
Updating PrivacyTools.io to PrivacyGuides.org

### DIFF
--- a/Awesome-Reddit.md
+++ b/Awesome-Reddit.md
@@ -143,4 +143,4 @@
 
 * [r/privacy](https://www.reddit.com/r/privacy) - *The intersection of technology, privacy, and freedom in a digital world*
 
-* [r/privacytoolsIO](https://www.reddit.com/r/privacytoolsIO) - *The PrivacyTools team is providing resources to protect your privacy against global, mass surveillance*
+* [r/PrivacyGuides](https://www.reddit.com/r/PrivacyGuides/) - *The PrivacyTools team is providing resources to protect your privacy against global, mass surveillance*

--- a/General-Awesome-Collection.md
+++ b/General-Awesome-Collection.md
@@ -23,7 +23,7 @@
 **Awesome Privacy**
 * [Pluja/awesome-privacy](https://github.com/pluja/awesome-privacy)
 * [KevinColemanInc/awesome-privacy](https://github.com/KevinColemanInc/awesome-privacy)
-* [Privacytools.io](https://www.privacytools.io/)
+* [PrivacyGuides.org](https://www.privacyguides.org/)
 * [Privacy Tool List By Chef-Kock](https://chef-koch.bearblog.dev/privacy-tools-list-by-chef-koch/)
 
 **Free Premium Leeches**


### PR DESCRIPTION
Privacytools has been depreciated.

Announcements:
[Nitter](https://nitter.net/privacy_guides/status/1443633412800225280)
[Reddit 1](https://www.reddit.com/r/PrivacyGuides/comments/pnh9n8/what_happened_to_privacytools/)
[Reddit 2](https://www.reddit.com/r/PrivacyGuides/comments/pnhn4a/rprivacyguides_privacyguidesorg_what_you_need_to/)


Also, the owner decided to put affiliate links to crypto exchanges on Privacytools